### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Installation
 ============
 
     git clone https://github.com/andrepl/rivalctl.git
+    cd rivalctl
     sudo python setup.py install
 
 Usage


### PR DESCRIPTION
I just added a `cd rivalctl` so that it can be copied from the repo and pasted into a terminal. In a current scenario, when a person pulls a repository, he is in some directory, not in rivalctl, thus `sudo python setup.py install` fails because probably in that directory there is no setup.py file.

Maybe it would be better to still keep in two lines, just edit the second line to be `sudo python rivalctl/setup.py install` :grey_question: 

:heart: :fireworks: 